### PR TITLE
Fix chrome download url with platform=linux param

### DIFF
--- a/content/getting_started/installation/en.md
+++ b/content/getting_started/installation/en.md
@@ -33,7 +33,7 @@ It might be a good idea to install applications that work in Zen. To complete [Z
 $ sudo apt-get install weston
 $ sudo apt-get install google-chrome-stable
 # If apt-get does not work, you can also download Chrome from
-# https://www.google.com/chrome/
+# https://www.google.com/chrome/?platform=linux
 ```
 
 ### Arch Linux

--- a/content/getting_started/installation/ja.md
+++ b/content/getting_started/installation/ja.md
@@ -33,7 +33,7 @@ $ sudo apt-get install adb clang cmake git libcairo2-dev \
 $ sudo apt-get install weston
 $ sudo apt-get install google-chrome-stable
 # apt-get でうまくインストールができない場合は、以下のURLからもChromeをインストールできます。
-# https://www.google.com/chrome/
+# https://www.google.com/chrome/?platform=linux
 ```
 
 ### Arch Linux


### PR DESCRIPTION
## Context

Ref: https://github.com/zwin-project/zwin.dev/issues/33

## Summary

Add `platform=linux` parameter to chrome downloading URL.

## How to check behavior

See the preview page.