### PR TITLE
🐛 Fix update document

### DIFF
--- a/content/getting_started/update/en.md
+++ b/content/getting_started/update/en.md
@@ -18,6 +18,13 @@ We recommend uninstalling Zen that is already installed on your system.
 
 Since required packages may have been updated, please install the packages again by following the [Install packages](/en/getting_started/installation#install-packages) section of the installation page.
 
+## Update zen-release-manager
+
+```shell
+$ cd /path/to/zen-release-manager
+$ git pull
+```
+
 ## Cleanup build directory
 
 To reduce build time, some build targets are not removed.

--- a/content/getting_started/update/ja.md
+++ b/content/getting_started/update/ja.md
@@ -17,6 +17,13 @@
 
 必要なパッケージが更新されている可能性がありますので、インストールページの[パッケージのインストール](/ja/getting_started/installation#パッケージのインストール)に従って、パッケージをインストールしてください。
 
+## zen-release-managerの更新
+
+```shell
+$ cd /path/to/zen-release-manager
+$ git pull
+```
+
 ## ビルドディレクトリのクリーンアップ
 
 ビルドディレクトリをクリーンアップします。


### PR DESCRIPTION
## Context

Forget to pull latest `zen-release-manager` when updating.

## Summary

Add instruction to fetch latest `zen-release-manager` when updating.

## How to check behavior

<!--
If you added a new feature, please write a way for other developers to easily
check the behavior you have changed or added so that they can catch up with the
changes.
-->
