### PR TITLE
Mention pip install step in getting_started/installation

### DIFF
--- a/content/getting_started/installation/en.md
+++ b/content/getting_started/installation/en.md
@@ -63,6 +63,7 @@ $ yay -S --needed weston google-chrome nautilus
 ```shell
 $ git clone https://github.com/zwin-project/zen-release-manager.git
 $ cd zen-release-manager
+$ pip3 install -r requirements.txt
 $ ./zen-release configure ./release/latest.yaml
 ```
 

--- a/content/getting_started/installation/ja.md
+++ b/content/getting_started/installation/ja.md
@@ -63,6 +63,7 @@ $ yay -S --needed weston google-chrome nautilus
 ```shell
 $ git clone https://github.com/zwin-project/zen-release-manager.git
 $ cd zen-release-manager
+$ pip3 install -r requirements.txt
 $ ./zen-release configure ./release/latest.yaml
 ```
 


### PR DESCRIPTION
## Context
[zen-release-manager's README](https://github.com/zwin-project/zen-release-manager#install-python-packages) says that it's required to execute `pip3 install -r requirements.txt` before doing configuration,  Installation step in [zwin.dev document](https://www.zwin.dev/ja/getting_started/installation#ビルドスクリプトの準備) doesn't mention about it. It might be helpful to add it.

## Summary

Added `pip3 install -r requrements.txt`

## How to check the behavior
