### PR TITLE
Add missing dependency 'cglm' for archlinux installation document

### DIFF
--- a/content/getting_started/installation/en.md
+++ b/content/getting_started/installation/en.md
@@ -48,7 +48,7 @@ $ yay -Syu
 ```shell
 $ yay -S --needed \
   git sudo clang make cmake meson ninja python python-pip curl unzip pkgconf \
-  wayland wayland-protocols wlroots0.15 glm glew librsvg ttf-ubuntu-font-family
+  wayland wayland-protocols wlroots0.15 glm cglm glew librsvg ttf-ubuntu-font-family
 ```
 
 It might be a good idea to install applications that work in Zen.

--- a/content/getting_started/installation/ja.md
+++ b/content/getting_started/installation/ja.md
@@ -48,7 +48,7 @@ $ yay -Syu
 ```shell
 $ yay -S --needed \
   git sudo clang make cmake meson ninja python python-pip curl unzip pkgconf \
-  wayland wayland-protocols wlroots0.15 glm glew librsvg ttf-ubuntu-font-family
+  wayland wayland-protocols wlroots0.15 glm cglm glew librsvg ttf-ubuntu-font-family
 ```
 
 私たちのデスクトップ環境で動作するアプリケーションをインストールしておくのも良いかもしれません。


### PR DESCRIPTION
## Context

'cglm' is required to `./zen-release build deps`, but it wasn't listed up in dependency list for archlinux.

## Summary

So I just append it into the document.
I read [AUR cglm package](https://aur.archlinux.org/packages/cglm) and confirmed that it's from [recp/cglm](https://github.com/recp/cglm), which is the same URL as one written in [Ubuntu's libcglm-dev package](https://packages.ubuntu.com/kinetic/libcglm-dev) (Of course, I can't take any responsibility to use them. But at leaset, I personally think it's safe to use one)

## How to check the behavior
